### PR TITLE
Bugfix. Analog data is always 16 bits according to JVS specification.

### DIFF
--- a/src/jvs.c
+++ b/src/jvs.c
@@ -402,7 +402,7 @@ JVSStatus processPacket()
 		case CMD_WRITE_ANALOG:
 		{
 			debug(1, "CMD_WRITE_ANALOG\n");
-			size = inputPacket.data[index + 1] + 2;
+			size = inputPacket.data[index + 1] * 2 + 2;
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
 		}
 		break;


### PR DESCRIPTION
Confirmed from English doc, original Japanese doc and my experiment with system 256 THE iDOLM@STER game.