### PR TITLE
README: add exA to platform list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ OpenJVS requires a USB RS485 dongle to communicate, and supports the following h
 | Namco System 256                | Working     | Yes                 |
 | Taito Type X+                   | Working     | Yes                 |
 | Taito Type X2                   | Working     | Yes                 |
+| exA-Arcadia                     | Working     |                     |
 
 On games that require a sense line, the following has to be wired up:
 


### PR DESCRIPTION
I haven't tested without a sense line, but I can confirm the exA works with one. Do you want me to test without the sense line? If so, should I leave it attached to ground but disconnected from the Pi?