### PR TITLE
- added threading.c/h and started moving Threading related stuff ther…

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -299,13 +299,16 @@ JVSConfigStatus parseRotary(char *path, int rotary, char *output)
             }
         }
         counter++;
+
+        if (line)
+        {
+            free(line);
+            line = NULL;
+            len = 0;
+        }
     }
 
     fclose(file);
-
-    if (line)
-        free(line);
-
     strcpy(output, rotaryGames[rotary]);
 
     return JVS_CONFIG_STATUS_SUCCESS;

--- a/src/config.h
+++ b/src/config.h
@@ -11,6 +11,8 @@
 #define MAX_PATH_LENGTH 1024
 #define MAX_LINE_LENGTH 1024
 
+/* Interval to poll rotary in seconds */
+#define TIME_POLL_ROTARY 1
 typedef struct
 {
     int senseLineType;

--- a/src/input.h
+++ b/src/input.h
@@ -4,6 +4,7 @@
 #include <linux/input.h>
 
 #include "io.h"
+#include "threading.h"
 
 #define WIIMOTE_DEVICE_NAME "nintendo-wii-remote"
 #define WIIMOTE_DEVICE_NAME_IR "nintendo-wii-remote-ir"
@@ -2377,5 +2378,7 @@ int evDevFromString(char *evDevString);
 int getInputs(DeviceList *deviceList);
 ControllerInput controllerInputFromString(char *controllerInputString);
 ControllerPlayer controllerPlayerFromString(char *controllerPlayerString);
+
+void ThreadManagerStopAll(void);
 
 #endif // INPUT_H_

--- a/src/rotary.h
+++ b/src/rotary.h
@@ -3,6 +3,7 @@
 
 typedef enum
 {
+    JVS_ROTARY_UNUSED,
     JVS_ROTARY_STATUS_ERROR,
     JVS_ROTARY_STATUS_SUCCESS
 } JVSRotaryStatus;

--- a/src/threading.c
+++ b/src/threading.c
@@ -1,0 +1,78 @@
+
+#include <string.h>
+#include <debug.h>
+
+#include "threading.h"
+
+static ThreadSharedData ThreadManagerData;
+
+/* Only call this function once from main-thread */
+void ThreadManagerInit(void)
+{
+    memset(&ThreadManagerData, 0, sizeof(ThreadManagerData));
+    pthread_mutex_init(&ThreadManagerData.mutex_manager, NULL);
+    pthread_mutex_init(&ThreadManagerData.mutex_threads, NULL);
+}
+
+int ThreadManagerCreate(void *thread_entry(void *), void *args)
+{
+    int retval = 0;
+
+    pthread_mutex_lock(&ThreadManagerData.mutex_manager);
+
+    if (ThreadManagerData.threadCount > THREAD_MAX_NUMBER)
+    {
+        debug(0, "Error: Could not create new thread - max number of threads reached(%d)\n", THREAD_MAX_NUMBER);
+        retval = -1;
+    }
+
+    if (retval == 0)
+    {
+        pthread_create(&ThreadManagerData.threadID[ThreadManagerData.threadCount], NULL, thread_entry, args);
+        ThreadManagerData.threadCount++;
+    }
+    pthread_mutex_unlock(&ThreadManagerData.mutex_manager);
+    return retval;
+}
+
+void ThreadManagerSetRunnable(void)
+{
+    ThreadSharedDataRunninSet(1);
+}
+
+void ThreadManagerStopAll(void)
+{
+    printf("Stopping threads\n");
+
+    /* Set flags for all threads to terminate itself */
+    ThreadSharedDataRunninSet(0);
+
+    pthread_mutex_lock(&ThreadManagerData.mutex_manager);
+
+    for (int i = 0; i < ThreadManagerData.threadCount; i++)
+    {
+        pthread_join(ThreadManagerData.threadID[i], NULL);
+        ThreadManagerData.threadID[i] = 0;
+    }
+
+    ThreadManagerData.threadCount = 0;
+
+    pthread_mutex_unlock(&ThreadManagerData.mutex_manager);
+}
+
+int ThreadSharedDataRunninGet(void)
+{
+    int retval;
+    pthread_mutex_lock(&ThreadManagerData.mutex_threads);
+    retval = ThreadManagerData.ThreadsRunning;
+    pthread_mutex_unlock(&ThreadManagerData.mutex_threads);
+
+    return retval;
+}
+
+void ThreadSharedDataRunninSet(int Running)
+{
+    pthread_mutex_lock(&ThreadManagerData.mutex_threads);
+    ThreadManagerData.ThreadsRunning = Running;
+    pthread_mutex_unlock(&ThreadManagerData.mutex_threads);
+}

--- a/src/threading.h
+++ b/src/threading.h
@@ -1,0 +1,24 @@
+#ifndef THREADING_H_
+#define THREADING_H_
+
+#include <pthread.h>
+
+#define THREAD_MAX_NUMBER 32
+
+typedef struct
+{
+    pthread_mutex_t mutex_manager;
+    pthread_t threadID[THREAD_MAX_NUMBER];
+    int threadCount;
+    /* Data to be shared between threads */
+    pthread_mutex_t mutex_threads;
+    int ThreadsRunning;
+} ThreadSharedData;
+
+void ThreadManagerInit(void);
+void ThreadManagerSetRunnable(void);
+void ThreadManagerStopAll(void);
+int ThreadManagerCreate(void *thread_entry(void *), void *args);
+void ThreadSharedDataRunninSet(int Running);
+int ThreadSharedDataRunninGet(void);
+#endif // THREADING_H_


### PR DESCRIPTION
…e for future usage when more thread will be added (e.g. rs232 boards support)

- all child-threads have a common signal for shutting down which will be accessed mutex protected to avoid race-conditions. Also more data can be shared across thread if necessary in the future (e.g. input config could be necessary of ffb stuff)
- rotary switch will be polled form time to time and OpenJvs configuration will be re-initialized so that no direct access to the pi is necessary to change game profiles. This is useful for standalone usage.
- fixed memory issue in parseRotary()