### PR TITLE
Systemd: parameterize for convenience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ install(TARGETS ${PROJECT_NAME}
 		LIBRARY DESTINATION "lib/"
 )
 
-install(FILES ${CMAKE_SOURCE_DIR}/docs/openjvs.service
+install(FILES ${CMAKE_SOURCE_DIR}/docs/openjvs.service ${CMAKE_SOURCE_DIR}/docs/openjvs@.service
 		COMPONENT ${PROJECT_NAME}
 		DESTINATION "/etc/systemd/system/"
 )

--- a/docs/openjvs@.service
+++ b/docs/openjvs@.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=OpenJVSService
+
+[Service]
+User=root
+Type=simple
+Restart=always
+RestartSec=10
+StartLimitIntervalSec=0
+ExecStart=/usr/bin/openjvs %I
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd service doesn't allow passing commandline arguments, but I thought it would be more useful to be able to specify what game profile to run. This updates it to use instance names. For example, you can `sudo systemctl start openjvs@sdoj`, and it'll run `/usr/bin/openjvs sdoj` under the hood.