### PR TITLE
Add sample udev rule

### DIFF
--- a/docs/85-openjvs.rules
+++ b/docs/85-openjvs.rules
@@ -1,0 +1,1 @@
+ACTION=="add", DRIVERS=="usbhid", ENV{ID_BUS}=="usb", RUN+="/bin/systemctl restart openjvs"


### PR DESCRIPTION
I've found this useful for restarting OpenJVS every time I add a new USB device. It gets placed in `/etc/udev/rules.d/85-openjvs.rules`.