### PR TITLE
Input: allow mapping analogue to digital

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -1,5 +1,6 @@
 #include "config.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -206,6 +207,19 @@ JVSConfigStatus parseOutputMapping(char *path, OutputMappings *outputMappings)
             continue;
 
         char *command = getNextToken(buffer, " ", &saveptr);
+        bool map_analogue_to_digital;
+        if (strcmp(command, "DIGITAL") == 0)
+        {
+            map_analogue_to_digital = true;
+            // DIGITAL is the first token for these, coming before the
+            // axis name; if we found DIGITAL, we need to read the next
+            // token for the actual axis.
+            command = getNextToken(NULL, " ", &saveptr);
+        }
+        else
+        {
+            map_analogue_to_digital = false;
+        }
 
         if (strcmp(command, "INCLUDE") == 0)
         {
@@ -218,7 +232,7 @@ JVSConfigStatus parseOutputMapping(char *path, OutputMappings *outputMappings)
         {
             jvsCapabilitiesFromString(&config.capabilities, getNextToken(NULL, " ", &saveptr));
         }
-        else if (command[11] == 'B')
+        else if (command[11] == 'B' || map_analogue_to_digital)
         {
             ControllerPlayer controllerPlayer = controllerPlayerFromString(getNextToken(NULL, " ", &saveptr));
             OutputMapping mapping = {

--- a/src/input.c
+++ b/src/input.c
@@ -162,6 +162,30 @@ void *deviceThread(void *_args)
                     continue;
                 }
 
+                // Useful for mapping analogue buttons to digital buttons,
+                // for example the triggers on a gamepad.
+                if (inputs.abs[event.code].type == SWITCH)
+                {
+                    // Allows mapping an axis button to a coin
+                    if (inputs.key[event.code].output == COIN)
+                    {
+                        if (event.value == inputs.absMax[event.code])
+                        {
+                            incrementCoin(inputs.key[event.code].jvsPlayer);
+                        }
+                        continue;
+                    }
+                    else if (event.value == inputs.absMin[event.code])
+                    {
+                        setSwitch(inputs.key[event.code].jvsPlayer, inputs.key[event.code].output, 0);
+                    }
+                    else
+                    {
+                        setSwitch(inputs.key[event.code].jvsPlayer, inputs.key[event.code].output, 1);
+                    }
+                    continue;
+                }
+
                 /* Handle the wii remotes differently */
                 if (wiiMode)
                 {
@@ -382,14 +406,14 @@ int processMappings(InputMappings *inputMappings, OutputMappings *outputMappings
             evInputs->absEnabled[inputMappings->mappings[i].code] = 1;
         }
 
-        if (inputMappings->mappings[i].type == ANALOGUE)
+        if (inputMappings->mappings[i].type == ANALOGUE && tempMapping.type == ANALOGUE)
         {
             evInputs->abs[inputMappings->mappings[i].code] = tempMapping;
             evInputs->abs[inputMappings->mappings[i].code].type = ANALOGUE;
             evInputs->absEnabled[inputMappings->mappings[i].code] = 1;
             evInputs->absMultiplier[inputMappings->mappings[i].code] = multiplier;
         }
-        else if (inputMappings->mappings[i].type == SWITCH)
+        else if (inputMappings->mappings[i].type == SWITCH || tempMapping.type == SWITCH)
         {
             evInputs->key[inputMappings->mappings[i].code] = tempMapping;
             evInputs->abs[inputMappings->mappings[i].code].type = SWITCH;


### PR DESCRIPTION
This enables support for mapping an analogue input to a digital button, useful for controllers which have inputs that only exist as axes. For example, the triggers on Xbox controllers are only presented as analogue inputs and can't otherwise be mapped to a button. To enable it, a new `DIGITAL` keyword was added, like so:

```
DIGITAL CONTROLLER_ANALOGUE_R CONTROLLER_1 BUTTON_3 PLAYER_1
```

In testing, the controller I had used `0` when not pressed and `255` when pressed, so there's no midpoint we could use to enable a secondary input. As a result, I left the secondary input disabled. I've tested this with both buttons and coin inputs.

Fixes #14.