### PR TITLE
Allow inserting more than one coin at once

### DIFF
--- a/src/controller/input.c
+++ b/src/controller/input.c
@@ -225,7 +225,7 @@ void *deviceThread(void *_args)
                 if (args->inputs.key[event.code].output == COIN)
                 {
                     if (event.value == 1)
-                        incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer);
+                        incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer, 1);
 
                     continue;
                 }
@@ -268,7 +268,7 @@ void *deviceThread(void *_args)
                     {
                         if (event.value == args->inputs.absMax[event.code])
                         {
-                            incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer);
+                            incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer, 1);
                         }
                         continue;
                     }
@@ -302,8 +302,11 @@ void *deviceThread(void *_args)
             {
                 if (args->inputs.key[event.code].output == COIN)
                 {
-                    if (event.value == 1)
-                        incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer);
+                    // The event's value is passed through, allowing the
+                    // source of the event to define how many coins to
+                    // insert at once.
+                    if (event.value > 0)
+                        incrementCoin(args->jvsIO, args->inputs.key[event.code].jvsPlayer, event.value);
 
                     continue;
                 }

--- a/src/jvs/io.c
+++ b/src/jvs/io.c
@@ -45,12 +45,12 @@ int setSwitch(JVSIO *io, JVSPlayer player, JVSInput switchNumber, int value)
 	return 1;
 }
 
-int incrementCoin(JVSIO *io, JVSPlayer player)
+int incrementCoin(JVSIO *io, JVSPlayer player, int amount)
 {
 	if (player == SYSTEM)
 		return 0;
 
-	io->state.coinCount[player - 1]++;
+	io->state.coinCount[player - 1] = io->state.coinCount[player - 1] + amount;
 	return 1;
 }
 

--- a/src/jvs/io.h
+++ b/src/jvs/io.h
@@ -189,7 +189,7 @@ JVSState *getState();
 
 int initIO(JVSIO *io);
 int setSwitch(JVSIO *io, JVSPlayer player, JVSInput switchNumber, int value);
-int incrementCoin(JVSIO *io, JVSPlayer player);
+int incrementCoin(JVSIO *io, JVSPlayer player, int amount);
 int setAnalogue(JVSIO *io, JVSInput channel, double value);
 int setGun(JVSIO *io, JVSInput channel, double value);
 int setRotary(JVSIO *io, JVSInput channel, int value);


### PR DESCRIPTION
This is a minor refactor that might be useful for other things in the future. Right now `incrementCoin` is hardcoded to inserting one coin at once, but there's no technical reason it has to be limited that way. I've updated the `CARD` path to use the value received from the input event, so that the bookkeeping software on the card can control how many credits to insert at once. The other callers still just insert one coin at once.