### PR TITLE
JVS: fix underflow bug in coin decrement

### DIFF
--- a/src/jvs/jvs.c
+++ b/src/jvs/jvs.c
@@ -420,12 +420,13 @@ JVSStatus processPacket(JVSIO *jvsIO)
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
 
-			/* Prevent underflow of coins */
-			if (coin_decrement > jvsIO->state.coinCount[0])
-				coin_decrement = jvsIO->state.coinCount[0];
-
 			for (int i = 0; i < jvsIO->capabilities.coins; i++)
+			{
+				/* Prevent underflow of coins */
+				if (coin_decrement > jvsIO->state.coinCount[i])
+					coin_decrement = jvsIO->state.coinCount[i];
 				jvsIO->state.coinCount[i] -= coin_decrement;
+			}
 		}
 		break;
 

--- a/src/jvs/jvs.c
+++ b/src/jvs/jvs.c
@@ -399,8 +399,16 @@ JVSStatus processPacket(JVSIO *jvsIO)
 		case CMD_WRITE_COINS:
 		{
 			debug(1, "CMD_WRITE_COINS\n");
-			size = 3;
+			size = 4;
+			int slot_index = inputPacket.data[index + 1];
+			int coin_increment = ((int)(inputPacket.data[index + 2]) | ((int)(inputPacket.data[index + 3]) << 8));
+
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
+
+			/* Prevent overflow of coins */
+			if (coin_increment + jvsIO->state.coinCount[slot_index] > 16383)
+				coin_increment = 16383 - jvsIO->state.coinCount[slot_index];
+			jvsIO->state.coinCount[slot_index] += coin_increment;
 		}
 		break;
 

--- a/src/jvs/jvs.c
+++ b/src/jvs/jvs.c
@@ -416,17 +416,15 @@ JVSStatus processPacket(JVSIO *jvsIO)
 		{
 			debug(1, "CMD_DECREASE_COINS\n");
 			size = 4;
+			int slot_index = inputPacket.data[index + 1];
 			int coin_decrement = ((int)(inputPacket.data[index + 2]) | ((int)(inputPacket.data[index + 3]) << 8));
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
 
-			for (int i = 0; i < jvsIO->capabilities.coins; i++)
-			{
-				/* Prevent underflow of coins */
-				if (coin_decrement > jvsIO->state.coinCount[i])
-					coin_decrement = jvsIO->state.coinCount[i];
-				jvsIO->state.coinCount[i] -= coin_decrement;
-			}
+			/* Prevent underflow of coins */
+			if (coin_decrement > jvsIO->state.coinCount[slot_index])
+				coin_decrement = jvsIO->state.coinCount[slot_index];
+			jvsIO->state.coinCount[slot_index] -= coin_decrement;
 		}
 		break;
 


### PR DESCRIPTION
This fixes an underflow bug I observed. The underflow check only checks the first slot, no matter how many coin slots there are, which means it applies the underflow-bounded check to all slots even if it's inappropriate. I observed this on a board whose IO test decrements a large number of coins from all slots. OpenJVS applied the decrement check based on the first slot, which had coins in it, which means that it underflowed the second slot by however many coins were in the first.

I haven't actually tested this yet, but should be the right fix.