### PR TITLE
Add missing newlines to debug() calls

### DIFF
--- a/src/hardware/device.c
+++ b/src/hardware/device.c
@@ -32,14 +32,14 @@ int initDevice(char *devicePath, int senseLineType, int senseLinePin)
   switch (senseLineType)
   {
   case 0:
-    debug(1, "Debug: No sense line set");
+    debug(1, "Debug: No sense line set\n");
     break;
   case 1:
-    debug(1, "Debug: Float/Sync sense line set");
+    debug(1, "Debug: Float/Sync sense line set\n");
     setGPIODirection(senseLinePin, IN);
     break;
   case 2:
-    debug(1, "Debug: Complex sense line set");
+    debug(1, "Debug: Complex sense line set\n");
     setGPIODirection(senseLinePin, OUT);
     break;
   default:

--- a/src/hardware/rotary.c
+++ b/src/hardware/rotary.c
@@ -15,28 +15,28 @@ JVSRotaryStatus initRotary()
     setupGPIO(18);
     if (!setGPIODirection(18, IN))
     {
-        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 18");
+        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 18\n");
         return JVS_ROTARY_STATUS_ERROR;
     }
 
     setupGPIO(19);
     if (!setGPIODirection(19, IN))
     {
-        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 19");
+        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 19\n");
         return JVS_ROTARY_STATUS_ERROR;
     }
 
     setupGPIO(20);
     if (!setGPIODirection(20, IN))
     {
-        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 20");
+        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 20\n");
         return JVS_ROTARY_STATUS_ERROR;
     }
 
     setupGPIO(21);
     if (!setGPIODirection(21, IN))
     {
-        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 21");
+        debug(1, "Warning: Failed to set Raspberry Pi GPIO Pin 21\n");
         return JVS_ROTARY_STATUS_ERROR;
     }
 

--- a/src/openjvs.c
+++ b/src/openjvs.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
     while (running != -1)
     {
         /* Init the watchdog to check the rotary and inputs */
-        debug(1, "Init watchdog");
+        debug(1, "Init watchdog\n");
         running = 1;
         setThreadsRunning(1);
         initWatchdog(&running, rotaryStatus);
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
         JVSIO io = {0};
         io.deviceID = 1;
 
-        debug(1, "Init inputs");
+        debug(1, "Init inputs\n");
         JVSInputStatus inputStatus = initInputs(config.defaultGamePath, config.capabilitiesPath, &io, config.autoControllerDetection);
         if (inputStatus != JVS_INPUT_STATUS_SUCCESS)
         {
@@ -109,7 +109,7 @@ int main(int argc, char **argv)
 
         debug(0, "  Output:\t\t%s\n", config.defaultGamePath);
 
-        debug(1, "Parse IO");
+        debug(1, "Parse IO\n");
         JVSConfigStatus ioStatus = parseIO(config.capabilitiesPath, &io.capabilities);
         if (ioStatus != JVS_CONFIG_STATUS_SUCCESS)
         {
@@ -125,7 +125,7 @@ int main(int argc, char **argv)
         }
 
         /* Init the Virtual IO */
-        debug(1, "Init IO");
+        debug(1, "Init IO\n");
         if (!initIO(&io))
         {
             debug(0, "Critical: Failed to init IO\n");
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
         }
 
         /* Setup the JVS Emulator with the RS485 path and capabilities */
-        debug(1, "Init JVS");
+        debug(1, "Init JVS\n");
         if (!initJVS(&io))
         {
             debug(0, "Critical: Could not initialise JVS\n");


### PR DESCRIPTION
I noticed a number of calls to `debug()` are missing a trailing newline. Most have it, but a few don't. This leads to messy-looking text in the debug logs:

```
Debug: Float/Sync sense line setInit watchdogInit inputsWarning: No outside mapping found for CONTROLLER_BUTTON_D
Warning: No outside mapping found for CONTROLLER_ANALOGUE_R
Warning: No outside secondary mapping found for HAT
```

There's one I didn't change, at the end of the `jvs` `processPacket` code, which just prints an empty string: https://github.com/OpenJVS/OpenJVS/blob/master/src/jvs/jvs.c#L483 Since that's basically a no-op right now, I'm not sure what it's meant to do.