### PR TITLE
Several coin-related bugfixes

### DIFF
--- a/src/jvs/jvs.c
+++ b/src/jvs/jvs.c
@@ -401,7 +401,7 @@ JVSStatus processPacket(JVSIO *jvsIO)
 			debug(1, "CMD_WRITE_COINS\n");
 			size = 4;
 			int slot_index = inputPacket.data[index + 1];
-			int coin_increment = ((int)(inputPacket.data[index + 2]) | ((int)(inputPacket.data[index + 3]) << 8));
+			int coin_increment = ((int)(inputPacket.data[index + 3]) | ((int)(inputPacket.data[index + 2]) << 8));
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
 
@@ -425,7 +425,7 @@ JVSStatus processPacket(JVSIO *jvsIO)
 			debug(1, "CMD_DECREASE_COINS\n");
 			size = 4;
 			int slot_index = inputPacket.data[index + 1];
-			int coin_decrement = ((int)(inputPacket.data[index + 2]) | ((int)(inputPacket.data[index + 3]) << 8));
+			int coin_decrement = ((int)(inputPacket.data[index + 3]) | ((int)(inputPacket.data[index + 2]) << 8));
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
 

--- a/src/jvs/jvs.c
+++ b/src/jvs/jvs.c
@@ -400,7 +400,8 @@ JVSStatus processPacket(JVSIO *jvsIO)
 		{
 			debug(1, "CMD_WRITE_COINS\n");
 			size = 4;
-			int slot_index = inputPacket.data[index + 1];
+			// - 1 because JVS is 1-indexed, but our array is 0-indexed
+			int slot_index = inputPacket.data[index + 1] - 1;
 			int coin_increment = ((int)(inputPacket.data[index + 3]) | ((int)(inputPacket.data[index + 2]) << 8));
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;
@@ -424,7 +425,8 @@ JVSStatus processPacket(JVSIO *jvsIO)
 		{
 			debug(1, "CMD_DECREASE_COINS\n");
 			size = 4;
-			int slot_index = inputPacket.data[index + 1];
+			// - 1 because JVS is 1-indexed, but our array is 0-indexed
+			int slot_index = inputPacket.data[index + 1] - 1;
 			int coin_decrement = ((int)(inputPacket.data[index + 3]) | ((int)(inputPacket.data[index + 2]) << 8));
 
 			outputPacket.data[outputPacket.length++] = REPORT_SUCCESS;


### PR DESCRIPTION
- In the PR where I implemented the correct coin slot behaviour for the increment/decrement commands, I introduced a new bug - JVS coin slots are 1-indexed, but OpenJVS's coin slot array is 0-indexed. As a result it was acting on the wrong slots.
- The coin counts from the increment/decrement commands were wrong. After reading up in the spec, I realized that the spec states the 16-bit coin value is sent as MSB, but OpenJVS is decoding them as LSB. I've flipped the byte order and it looks correct now. Before this patch, I was seeing coins being added and removed in increments of 256 instead of 1.