### PR TITLE
Update joystick detection to include BTN_TRIGGER

### DIFF
--- a/src/controller/input.c
+++ b/src/controller/input.c
@@ -593,7 +593,7 @@ JVSInputStatus getInputs(DeviceList *deviceList)
         if (test_bit_diff(EV_KEY, bit[0]))
         {
             ioctl(device, EVIOCGBIT(EV_KEY, KEY_MAX), bit[EV_KEY]);
-            if (test_bit_diff(BTN_START, bit[EV_KEY]))
+            if (test_bit_diff(BTN_START, bit[EV_KEY]) || test_bit_diff(BTN_TRIGGER, bit[EV_KEY]))
                 deviceList->devices[i].type = DEVICE_TYPE_JOYSTICK;
         }
 


### PR DESCRIPTION
Hi Dear,
Retro Shooter IR Light gun (RS3 Reaper) emulates 3 types of devices:
 - Keyboard
 - Mouse
 - Joystick

In Joystick mode, we have ABS_X & ABS_Y and  all other input events.
But there is no START Button, so let's check on TRIGGER also so the device is taken into account by openjvs.

Thanks
Fred